### PR TITLE
Missing configuration disables plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,10 @@ class LogForwardingPlugin {
     const stage = this.options.stage && this.options.stage.length > 0
       ? this.options.stage
       : service.provider.stage;
+    if (!service.custom.logForwardingKinesis) {
+      this.serverless.cli.log('"custom.logForwardingKinesis" cannot be found, disabling log forwarding');
+      return;
+    }
     if (service.custom.logForwardingKinesis.stages &&
       service.custom.logForwardingKinesis.stages.indexOf(stage) === -1) {
       this.serverless.cli.log(`Log Forwarding is ignored for ${stage} stage`);


### PR DESCRIPTION
The idea behind this change is that in case the configuration is missing then instead of failing with error, the plugin will be disabled and the log forwarding attributes are not going to be added.